### PR TITLE
full rewrite, new +1 offset, docs, tests, BCE leap years

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,17 @@ This treats the Gregorian calendar as proleptic, continuing with leap years ever
 ```
 const decimaldate = require('./decimaldate');
 
-console.log( decimaldate.iso2dec('2000-02-28') )
-console.log( decimaldate.iso2dec('+2000-02-28') )
-console.log( decimaldate.iso2dec('+2000-02-28') )
+console.log( decimaldate.iso2dec('2000-02-28') )    // 2000.15984
 
-console.log( decimaldate.iso2dec('-1900-01-31')  ) # a BCE year with a large decimal portion, since Jan 1 -1900 is further from 0
+console.log( decimaldate.iso2dec('540-01-31')  )  // 540.08333   note the small decimal portion, since Jan 1 is closer to 0 origin when CE
+console.log( decimaldate.iso2dec('-540-01-31')  ) // -539.91667  note the large decimal portion, since Jan 1 is further from 0 origin when BCE
 
-console.log( decimaldate.iso2dec('1900-02-29')  ) # error, this would not have been a leap year
+console.log( decimaldate.iso2dec('1900-02-29')  ) //  error, this would not have been a leap year
 
-console.log( decimaldate.dec2iso(1999.0013700) )
-console.log( decimaldate.dec2iso(1999.497260) )
-console.log( decimaldate.dec2iso(-1999.9164383) )
-console.log( decimaldate.dec2iso(-1999.0835617) )
+console.log( decimaldate.dec2iso(1999.0013700) )    // 1999-01-01
+console.log( decimaldate.dec2iso(1999.497260) )     // 1999-07-01
+console.log( decimaldate.dec2iso(-550.9164383) )    // -0551-01-31  negative year, large decimal portion because January is further from 0 origin
+console.log( decimaldate.dec2iso(-550.0835617) )    // -0551-12-01  negative year, small decimal portion because December is closer to 0 origin
 ```
 
 
@@ -45,13 +44,34 @@ decimaldate.dec2iso(decimaldate.iso2dec('-1000-06-30'))  // -1000-06-30
 ```
 
 
-### Year 0 and Subtracting Dates
+### Year 0 and the Number Line
 
-The Gregorian calendar has no year 0. The morning after Dec 31 of 1 BCE would be Jan 1 of 1 CE.
+The Gregorian calendar has no year 0, and the morning after Dec 31 of 1 BCE would be Jan 1 of 1 CE.
 
-This is important to keep in mind when trying to subtract one date from another, and crossing the CE/BCE boundary: _You must subtract 2 years from the mathematical difference_ to find the real difference.
+On a number line from BCE to CE, the value 0 would appear at the cusp between December 31 1 BCE (0000-12-31) and January 1 1 CE (0001-01-01).
 
-This is a known issue with calculating differences across the BCE/CE boundary, and is not novel to this expression of dates as decimal format.
+Decimaldate can be thought of as an offset on that number line.
+- +0.25 would be 3 months forward into 1 CE (early April)
+- +1.5 would be a year and a half forward from 0, so early July of 2 CE
+- -0.5 would be half a year backward into 1 BCE (early October)
+- -1.5 would be a year and a half backward from 0, so early July of 2 BCE
+
+However, decimaldate shifts the origin by 1 year to make positive dates look more intuitive. While it is mathematically correct that +2022.9 is November 2023, people reading decimal dates visually just didn't like the numbers looking like that. As such, +1 is added to decimal dates.
+
+| true decimal | decimaldate | iso | comment |
+| --- | --- | --- | --- |
+| -1.998633 | -0.998633 | -0001-01-01 | first day of 2 CE, most negative (highest decimal portion) day of the year |
+| -1.001366 | -0.001366 | -0001-12-31 | the last day of 2 BCE, least negative (lowest decimal portion) day of the year |
+| -0.998633 | 0.001367 | 0000-01-01 | first day of 1 BCE, most negative (highest decimal portion) day of the year |
+| -0.5 | 0.5 | 0000-07-02 | middle of 1 BCE, 6 months before the 0 origin of Jan 1 1 CE |
+| -0.001366 | 0.998634 | 0000-12-31 | the last day of 1 BCE, least negative (lowest decimal portion) day of the year |
+| 0 | 1 | cusp | the cusp between Dec 31 1 BCE (0000-12-31) and Jan 1 1 CE (0001-01-01) |
+| +0.001369 | +1.001369 | 0001-01-01 | the first day of 1 CE, least positive day of the year |
+| +0.5 | +1.5 | 0001-07-01 | middle of 1 CE, 6 months after the 0 origin of Jan 1 1 CE |
+| +0.998631 | +1.998631 | 0001-12-31 | last day of 1 CE, most positive day of the year |
+| +1.001369 | +2.001369 | 0002-01-01 | the first day of 2 CE, least positive day of the year |
+| +1.998631 | +2.998631 | 0002-12-31 | last day of 2 CE, most positive day of the year |
+
 
 
 ### Our Use Case and Technical Challenges

--- a/decimaldate.js
+++ b/decimaldate.js
@@ -4,53 +4,70 @@
  */
 
 
+const DECIMALPLACES = 5;
+const RE_YEARMONTHDAY = /^(\-?\+?)(\d+)\-(\d\d)\-(\d\d)$/;
+
+
 exports.iso2dec = iso2dec = (isodate) => {
+    // parse the date into 3 integers and maybe a minus sign
+    // validate that it's a valid date
     const datepieces = isodate.match(RE_YEARMONTHDAY);
-    if (! datepieces) throw (`Invalid date format ${isodate}`);
+    if (! datepieces) throw new Error(`iso2dec() malformed date ${isodate}`);
 
-    [plusminus, yearstring, monthstring, daystring] = datepieces.slice(1);
-    if (! isvalidmonth(monthstring) || ! isvalidmonthday(yearstring, monthstring, daystring))  throw `Invalid date ${isodate}`;
+    const [plusminus, yearstring, monthstring, daystring] = datepieces.slice(1);
+    const monthint = parseInt(monthstring);
+    const dayint = parseInt(daystring);
+    let yearint = plusminus == '-' ? -1 * parseInt(yearstring) : parseInt(yearstring);
+    if (yearint <= 0) yearint -= 1;  // ISO 8601 shift year<=0 by 1, 0=1BCE, -1=2BCE; we want proper negative integer
+    if (! isvalidmonthday(yearint, monthint, dayint))  throw new Error(`iso2dec() invalid date ${isodate}`);
 
-    let decbit = proportionofdayspassed(yearstring, monthstring, daystring);
-    if (plusminus == '-') decbit = 1 - decbit;
+    // number of days passed = decimal portion
+    // if BCE <=0 then count backward from the end of the year, instead of forward from January
+    const decbit = proportionofdayspassed(yearint, monthint, dayint);
 
-    let yeardecimal = parseInt(yearstring) + decbit;
-    if (plusminus == '-' && yeardecimal > 0) {  // ISO 8601 shift and year<=0 by 1, 0=1BCE, -1=2BCE
-        yeardecimal -= 1;
+    let decimaloutput;
+    if (yearint < 0) {
+        // ISO 8601 shift year<=0 by 1, 0=1BCE, -1=2BCE; we want string version
+        // so it's 1 to get from the artificially-inflated integer (string 0000 => -1 for math, +1 to get back to 0)
+        decimaloutput = 1 + 1 + yearint - (1 - decbit);
     }
-    if (plusminus == '-') yeardecimal *= -1;
+    else {
+        decimaloutput = yearint + decbit;
+    }
 
-    return parseFloat(yeardecimal.toFixed(DECIMALPLACES));
+    // round to standardized number of decimals
+    decimaloutput = parseFloat(decimaloutput.toFixed(DECIMALPLACES));
+    return decimaloutput;
 };
 
 
 exports.dec2iso = dec2iso = (decdate) => {
-    // strip the integer/year part
-    // find how many days were in this year, multiply back out to get the day-of-year number
-    if (decdate >= 0) {
-        yearint = parseInt(Math.abs(Math.floor(decdate)));
-        plusminus = '';
+    // remove the artificial +1 that we add to make positive dates look intuitive
+    const truedecdate = decdate - 1;
+    const ispositive = truedecdate > 0;
+
+    // get the integer year
+    if (ispositive) {
+        yearint = Math.floor(truedecdate) + 1;
     }
     else {
-        yearint = parseInt(Math.abs(Math.ceil(decdate)));
-        plusminus = '-';
+        yearint = -Math.abs(Math.floor(truedecdate));  // ISO 8601 shift and year<=0 by 1, 0=1BCE, -1=2BCE
     }
 
-    let yearstring = yearint + "";
-    const dty = daysinyear(yearstring);
-    let targetday = dty * (Math.abs(decdate) % 1);
-    targetday = decdate >= 0 ? Math.ceil(targetday) : Math.floor(targetday);
-    if (decdate < 0) targetday = dty - targetday;
+    // how many days in year X decimal portion = number of days into the year
+    // if it's <0 then we count backward from the end of the year, instead of forward into the year
+    const dty = daysinyear(yearint);
+    let targetday = dty * (Math.abs(truedecdate) % 1);
+    if (ispositive) targetday = Math.ceil(targetday);
+    else targetday = dty - Math.floor(targetday);
 
     // count up days months at a time, until we reach our target month
-    // the the remainder days is the day of the month, offset by 1 cuz we count from 0
-    const months = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
-    let monthstring;
+    // then the remainder (days) is the day of that month
+    let monthint;
     let dayspassed = 0;
-    for (var i=0, l=months.length; i<l; i++) {
-        monthstring = months[i];
-
-        const dtm = daysinmonth(yearstring, monthstring);
+    for (let m = 1; m <= 12; m++) {
+        monthint = m;
+        const dtm = daysinmonth(yearint, monthint);
         if (dayspassed + dtm < targetday) {
             dayspassed += dtm;
         }
@@ -58,85 +75,91 @@ exports.dec2iso = dec2iso = (decdate) => {
             break;
         }
     }
+    const dayint = targetday - dayspassed;
 
-    const daynumber = targetday - dayspassed;
-    const daystring = (daynumber < 10 ? "0" : "") + daynumber;
+    // make string output
+    // months and day as 2 digits
+    // ISO 8601 shift year<=0 by 1, 0=1BCE, -1=2BCE
+    const monthstring = monthint.toString().padStart(2, '0');
+    const daystring = dayint.toString().padStart(2, '0');
+    let yearstring;
+    if (yearint > 0) yearstring = yearint.toString().padStart(4, '0');  // just the year as 4 digits
+    else if (yearint == -1) yearstring = (Math.abs(yearint + 1).toString().padStart(4, '0'));  // BCE offset by 1 but do not add a - sign
+    else yearstring = '-' + (Math.abs(yearint + 1).toString().padStart(4, '0'));  // BCE offset by 1 and add  - sign
 
-    if (plusminus == '-') yearstring = (yearint + 1) + "";  // ISO 8601 shift and year<=0 by 1, 0=1BCE, -1=2BCE
-
-    return `${plusminus}${yearstring}-${monthstring}-${daystring}`;
+    return `${yearstring}-${monthstring}-${daystring}`;
 };
 
 
-const DECIMALPLACES = 6;
-
-const RE_YEARMONTHDAY = /^(\-?\+?)(\d+)\-(\d\d)\-(\d\d)$/;
-
-
-const isvalidmonth = (monthstring) => {
-    validmonths = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
-    return validmonths.indexOf(monthstring) != -1;
+exports.daysinyear = daysinyear = (yearint) => {
+    return isleapyear(yearint) ? 366 : 365;
 };
 
 
-const isvalidmonthday = (yearstring, monthstring, daystring) => {
-    days = parseInt(daystring);
-    if (isNaN(days)) return false;
-    if (days < 0) return false;
-    if (days > daysinmonth(yearstring, monthstring)) return false;
+exports.isleapyear = isleapyear = (yearint) => {
+    if (yearint != parseInt(yearint) || yearint == 0) throw new Error(`isleapyear() invalid year ${yearint}`);
+
+    // don't forget BCE; there is no 0 so leap years are -1, -5, -9, ..., -2001, -2005, ...
+    // just add 1 to the year to correct for this, for this purpose
+    const yearnumber = yearint > 0 ? yearint : yearint + 1;
+
+    const isleap = yearnumber % 4 == 0 && (yearnumber % 100 != 0 || yearnumber % 400 == 0);
+    return isleap;
+};
+
+
+exports.daysinmonth = daysinmonth = (yearint, monthint) => {
+    const monthdaycounts = {
+        1: 31,
+        2: 28,  // February
+        3: 31,
+        4: 30,
+        5: 31,
+        6: 30,
+        7: 31,
+        8: 31,
+        9: 30,
+        10: 31,
+        11: 30,
+        12: 31,
+    };
+
+    if (isleapyear(yearint)) monthdaycounts[2] = 29;
+
+    return monthdaycounts[monthint];
+};
+
+
+exports.isvalidmonthday = isvalidmonthday = (yearint, monthint, dayint) => {
+    if (yearint != parseInt(yearint) || yearint == 0) return false;
+    if (monthint != parseInt(monthint)) return false;
+    if (dayint != parseInt(dayint)) return false;
+
+    if (monthint < 1 || monthint > 12) return false;
+    if (dayint < 1) return false;
+
+    const dtm = daysinmonth(yearint, monthint);
+    if (! dtm) return false;
+    if (dayint > dtm) return false;
+
     return true;
 };
 
 
-const proportionofdayspassed = (yearstring, monthstring, daystring) => {
-    // count the number of days to get to this day of this month
+exports.proportionofdayspassed = proportionofdayspassed = (yearint, monthint, dayint) => {
+    // count the number of days to get through the prior months
     let dayspassed = 0;
-    ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-    .forEach((tms) => {
-        if (tms < monthstring) dayspassed += daysinmonth(yearstring, tms);
-    });
-    dayspassed += parseInt(daystring);
+    for (let m = 1; m < monthint; m++) {
+        const dtm = daysinmonth(yearint, m);
+        dayspassed += dtm;
+    }
 
-    // subtract 1 cuz day 0 is January 1 and not January 0
-    // add 0.5 to get us 12 noon
-    dayspassed -= 1;
-    dayspassed += 0.5;
+    // add the leftover days not in a prior month
+    // but minus 0.5 to get us to noon of the target day, as opposed to the end of the day
+    dayspassed = dayspassed + dayint - 0.5;
 
-    // divide by days in year, to get decimal portion since noon of Jan 1
-    const dty = daysinyear(yearstring);
+    // divide by days in year, to get decimal portion
+    // even January 1 is 0.5 days in since we snap to 12 noon
+    const dty = daysinyear(yearint);
     return dayspassed / dty;
-};
-
-
-const daysinmonth = (yearstring, monthstring) => {
-    monthdaycounts = {
-        '01': 31,
-        '02': 28,  // February
-        '03': 31,
-        '04': 30,
-        '05': 31,
-        '06': 30,
-        '07': 31,
-        '08': 31,
-        '09': 30,
-        '10': 31,
-        '11': 30,
-        '12': 31,
-    };
-
-    if (isleapyear(yearstring)) monthdaycounts['02'] = 29;
-
-    return monthdaycounts[monthstring];
-};
-
-
-const daysinyear = (yearstring) => {
-    return isleapyear(yearstring) ? 366 : 365;
-};
-
-
-const isleapyear = (yearstring) => {
-    yearnumber = parseInt(yearstring);
-    const isleap = yearnumber % 4 == 0 && (yearnumber % 100 != 0 || yearnumber % 400 == 0);
-    return isleap;
 };

--- a/tests.js
+++ b/tests.js
@@ -5,32 +5,42 @@ const decimaldate = require('./decimaldate');
 
 // a list of tests: function, input, output
 const tests = [
-    ['dec2iso', 0.5, '0-07-01'],
-    ['dec2iso', -0.5, '-1-07-01'],
-    ['iso2dec', '0000-07-01', 0.498634],
-    ['iso2dec', '-0001-07-01', -0.50274],
-    ['iso2dec', '2000-01-01', 2000.001366],
-    ['iso2dec', '1999-01-01', 1999.001370],
-    ['iso2dec', '2000-12-31', 2000.998634],
-    ['iso2dec', '+1999-12-31', 1999.998630],
-    ['iso2dec', '+1999-07-01', 1999.497260],
-    ['iso2dec', '-2000-01-01', -1999.998634],
-    ['iso2dec', '-2000-12-31', -1999.001366],
-    ['iso2dec', '-1000000-01-01', -999999.998634],
-    ['iso2dec', '-1000000-12-31', -999999.001366],
-    ['dec2iso', 2000.001366, '2000-01-01'],
-    ['dec2iso', 1999.001370, '1999-01-01'],
-    ['dec2iso', 2000.998634, '2000-12-31'],
-    ['dec2iso', 1999.998630, '1999-12-31'],
-    ['dec2iso', 1999.497260, '1999-07-01'],
-    ['dec2iso', 1999.5, '1999-07-02'],
-    ['dec2iso', 2000.5, '2000-07-01'],
-    ['dec2iso', -2000.998634, '-2001-01-01'],
-    ['dec2iso', -2000.001366, '-2001-12-31'],
-    ['dec2iso', -2994.998634, '-2995-01-01'],
-    ['dec2iso', -2994.001366, '-2995-12-31'],
-    ['dec2iso', -1000000.998634, '-1000001-01-01'],
-    ['dec2iso', -1000000.001366, '-1000001-12-31'],
+    ['isleapyear', 2000, true],
+    ['isleapyear', 1900, false],
+    ['isleapyear', 1, false],
+    ['isleapyear', 4, true],
+    ['isleapyear', -1, true],
+    ['isleapyear', -2000, false],
+    ['isleapyear', -1900, false],
+    ['isleapyear', -2001, true],
+    ['isleapyear', -1901, false],
+    ['dec2iso', -0.998633, '-0001-01-01'],
+    ['dec2iso', -0.5, '-0001-07-02'],  // non leap year, 1823rd day is July 2
+    ['dec2iso', -0.001366, '-0001-12-31'],
+    ['dec2iso', 0.001367, '0000-01-01'],
+    ['dec2iso', 0.5, '0000-07-01'],  // 1 BCE, leap year; 183rd day is July 1 due to February being longer
+    ['dec2iso', 0.998634, '0000-12-31'],  // 1 BCE, leap year; 183rd day is July 1 due to February being longer
+    ['dec2iso', +1.001369, '0001-01-01'],
+    ['dec2iso', +1.5, '0001-07-02'],  // non leap year, 1823rd day is July 2
+    ['dec2iso', +1.998631, '0001-12-31'],
+    ['dec2iso', +2.001369, '0002-01-01'],
+    ['dec2iso', +2.5, '0002-07-02'],  // non leap year, 1823rd day is July 2
+    ['dec2iso', +2.998631, '0002-12-31'],
+    ['iso2dec', '-0002-01-01', -1.99863],
+    ['iso2dec', '-0002-07-02', -1.5],  // non leap year, 1823rd day is July 2
+    ['iso2dec', '-0002-12-31', -1.00137],
+    ['iso2dec', '-0001-01-01', -0.99863],
+    ['iso2dec', '-0001-07-02', -0.5],  // non leap year, 1823rd day is July 2
+    ['iso2dec', '-0001-12-31', -0.00137],
+    ['iso2dec', '0000-01-01', 0.00137],  // 1 BCE, leap year; 183rd day is July 1 due to February being longer
+    ['iso2dec', '0000-07-02', 0.50137],  // 1 BCE, leap year; 183rd day is July 1 due to February being longer
+    ['iso2dec', '0000-12-31', 0.99863],
+    ['iso2dec', '0001-01-01', +1.00137],
+    ['iso2dec', '0001-07-02', +1.5],  // non leap year, 1823rd day is July 2
+    ['iso2dec', '0001-12-31', +1.99863],
+    ['iso2dec', '0002-01-01', +2.00137],
+    ['iso2dec', '0002-07-02', +2.5],  // non leap year, 1823rd day is July 2
+    ['iso2dec', '0002-12-31', +2.99863],
 ];
 
 console.log("Starting tests.")
@@ -39,19 +49,19 @@ let failcount = 0;
 
 tests.forEach(([funcname, argin, wantout]) => {
     const got = decimaldate[funcname](argin);
-    const ok = got == wantout;
+    const ok = got === wantout;
 
     if (ok) {
-        console.log('OK');
+        console.log(`OK    ${funcname}(${argin}) = ${wantout}`);
         passcount++;
     }
     else {
         failcount++;
-        console.log(`FAIL ${funcname}(${argin}) returned ${got} instead of expected ${wantout}`);
+        console.log(`FAIL    ${funcname}(${argin}) returned ${got} instead of expected ${wantout}`);
     }
 });
 
-
+console.log("");
 console.log("All tests done.")
 console.log(`${passcount} tests OK.`);
 console.log(`${failcount} tests failed.`);


### PR DESCRIPTION
Okay, here's the full rewrite per the new specification discussed in https://github.com/OpenHistoricalMap/decimaldate-javascript/issues/3

- rewrite to internally use proper integers; I had originally designed for string operations which was silly but seemed to fit a need at the time
- handling of leap years BCE now works
- per instructions, added +1 to generated decimals so years >0 look more intuitive
- test cases and documentation
